### PR TITLE
fix Listing request types cast to Array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 group: edge
 language: node_js
 node_js:
-- '5.4'
-- '4.1'
-- '6.0'
+- '6.10.3'
+- '7.10.0'
 before_script:
 - npm install -g mocha babel-cli
 - npm run compile

--- a/es6/Parser.js
+++ b/es6/Parser.js
@@ -47,13 +47,11 @@ export default class Parser {
    */
   static cast ( value, key ) {
     
-    if (!isNaN( value )) {
-      return Number( value )
-    }
+    if (!isNaN( value ))   return Number( value )
 
-    if (value === "true" || value === "false") {
-      return Boolean( value )
-    }
+    if (value === "true")  return true
+
+    if (value === "false") return false
 
     if (typeof key === 'string' && dateNodes[key.toLowerCase()]) {
       return new Date( value )
@@ -66,8 +64,8 @@ export default class Parser {
    * recursively flattens `value` keys in the XML -> JSON conversion
    * we can do this because we don't need to worry about XML attributes from eBay
    *
-   * @param      {<type>}  o       { parameter_description }
-   * @return     {<type>}  { description_of_the_return_value }
+   * @param      {Object}  o       the object output from the XML parser
+   * @return     {Object}          the flattened output
    */
   static flatten ( o, key ) {
 

--- a/es6/Request.js
+++ b/es6/Request.js
@@ -23,6 +23,7 @@ const day     = 24 * hour
 const PROD    = "production"
 const HEADING = 'xml version="1.0" encoding="utf-8"?'
 const LIST    = "List"
+const LISTING = "Listing"
 const log     = debug("ebay:request")
 /**
  * Immmutable request object for making eBay API verbs
@@ -223,7 +224,7 @@ export default class Request {
     const fields = this.fieldKeys
     while (fields.length) {
       const field = fields.pop()
-      if ( ~field.indexOf(LIST) ) return field
+      if ( ~field.indexOf(LIST) && !field.indexOf(LISTING) ) return field
     }
     return false
   }

--- a/es6/Request.js
+++ b/es6/Request.js
@@ -224,7 +224,8 @@ export default class Request {
     const fields = this.fieldKeys
     while (fields.length) {
       const field = fields.pop()
-      if ( ~field.indexOf(LIST) && !field.indexOf(LISTING) ) return field
+      if (~field.indexOf(LISTING)) continue
+      if (~field.indexOf(LIST)) return field
     }
     return false
   }

--- a/test/Ebay.Parser.spec.js
+++ b/test/Ebay.Parser.spec.js
@@ -1,0 +1,11 @@
+import {expect} from 'chai'
+import Parser   from '../lib/Parser'
+
+describe("<Ebay.Parser>", function () {
+  it("Parser.cast()", function () {
+    expect(Parser.cast("true")).to.equal(true)
+    expect(Parser.cast("false")).to.equal(false)
+    expect(Parser.cast("1")).to.equal(1)
+    expect(Parser.cast("taters")).to.equal("taters")
+  })
+})

--- a/test/Ebay.Request.spec.js
+++ b/test/Ebay.Request.spec.js
@@ -62,6 +62,11 @@ describe("<Ebay.Request>", function () {
     expect(req.endpoint).to.equal(Endpoints.Trading.production)
   })
 
+  it("does not cast Listing prefixed keys to Array (issue #47)", function () {
+    const req = Ebay.create().GetOrders().ListingType("fake")
+    expect(req.listKey()).to.equal(false)
+  })
+
   it.skip("Queues and rate limits", function () {
     expect(Ebay.Request).to.have.property("RATELIMIT")
   })


### PR DESCRIPTION
1. fixes a bad `Boolean` cast
2. fixes Listing request types being cast to Array by checking that the Request key does not contain `Listing`