### PR TITLE
fix #51, use whitelist for conversion of numbers

### DIFF
--- a/es6/Parser.js
+++ b/es6/Parser.js
@@ -1,9 +1,10 @@
-import Promise    from "bluebird"
-import ecjson     from "ecjson"
-import {throws}   from "./errors"
-import Immutable  from "./utils/Immutable"
-import Extraneous from "./definitions/extraneous"
-import dateNodes  from "./definitions/nodes.date"
+import Promise      from "bluebird"
+import ecjson       from "ecjson"
+import {throws}     from "./errors"
+import Immutable    from "./utils/Immutable"
+import Extraneous   from "./definitions/extraneous"
+import dateNodes    from "./definitions/nodes.date"
+import numericNodes from "./definitions/nodes.numeric"
 
 const ITERABLE_KEY = /Array|List/
 
@@ -12,7 +13,7 @@ const ITERABLE_KEY = /Array|List/
  * should generally be bound to a Request via:
  *   `Function.prototype.bind`
  *   `Promise.prototype.bind`
- *  
+ *
  */
 export default class Parser {
 
@@ -20,7 +21,7 @@ export default class Parser {
    * converts an XML response to JSON
    *
    * @param      {XML}     xml     The xml
-   * @return     {Promise}         resolves to a JSON representation of the HTML 
+   * @return     {Promise}         resolves to a JSON representation of the HTML
    */
   static toJSON ( xml ) {
     return new Promise( (resolve, reject)=> {
@@ -46,15 +47,19 @@ export default class Parser {
    * @return     {Date|Number}          The cast value
    */
   static cast ( value, key ) {
-    
-    if (!isNaN( value ))   return Number( value )
 
     if (value === "true")  return true
 
     if (value === "false") return false
 
-    if (typeof key === 'string' && dateNodes[key.toLowerCase()]) {
-      return new Date( value )
+    if (key) {
+      if (typeof key === 'string' && dateNodes[key.toLowerCase()]) {
+        return new Date( value )
+      }
+
+      if (!isNaN( value ) && numericNodes[key.toLowerCase()]) {
+        return Number( value )
+      }
     }
 
     return value
@@ -85,7 +90,7 @@ export default class Parser {
       deflated[key] = Parser.flatten(o[key], key)
       return deflated
     }, {})
-    
+
   }
 
   /**
@@ -101,10 +106,10 @@ export default class Parser {
     delete obj.PaginationResult
 
     return { pagination: {
-        pages  : p.TotalNumberOfPages   || 0
-      , length : p.TotalNumberOfEntries || 0
+        pages  : Number(p.TotalNumberOfPages)   || 0
+      , length : Number(p.TotalNumberOfEntries) || 0
     }}
-    
+
   }
   /**
    * cleans the Ebay response up
@@ -127,7 +132,7 @@ export default class Parser {
       }, {})
 
    return Parser.fold(res)
-  
+
   }
 
   /**
@@ -155,7 +160,7 @@ export default class Parser {
       }
 
       cleaned[key] = value
-      return cleaned      
+      return cleaned
     }, {})
   }
 

--- a/es6/definitions/nodes.numeric.js
+++ b/es6/definitions/nodes.numeric.js
@@ -1,0 +1,3 @@
+module.exports = {
+  categorycount: true
+}

--- a/test/Ebay.Functional.spec.js
+++ b/test/Ebay.Functional.spec.js
@@ -54,7 +54,7 @@ describe("<Ebay> => Functional Testing", function () {
 
   })
 
-  it("lists items", function (done) {
+  it("creates listings", function (done) {
     const items = Array(3).fill(0).map(mock.Item)
     Promise.resolve(items)
       .map( item => ebay.Item(item).AddFixedPriceItem().run() )
@@ -73,7 +73,7 @@ describe("<Ebay> => Functional Testing", function () {
       .catch(done)
   })
 
-  it("casts to Number", function (done) {
+  it("casts CategoryCount to Number", function (done) {
     ebay
       .GetSuggestedCategories()
       .Query("men's")

--- a/test/Ebay.Functional.spec.js
+++ b/test/Ebay.Functional.spec.js
@@ -10,10 +10,31 @@ process.env.EBAY_SANDBOX = true
 describe("<Ebay> => Functional Testing", function () {
   // Load encrypted creds on CI
 
-  const env = require('./fixtures/auth.private.js')
-  Object.keys(env).forEach( v => process.env[v] = env[v] )
+  let env;
+  try {
+    env = require('./fixtures/auth.private.js')
+    Object.keys(env).forEach( v => process.env[v] = env[v] )
+  } catch (err) {
+    // pass
+  }
 
-  const ebay = Ebay.fromEnv()
+  let ebay;
+  try {
+    ebay = Ebay.fromEnv();
+  } catch (err) {
+    console.warn(`
+      Unable to initialize Ebay object, skipping functional tests.
+      Need environment or test/fixtures/auth.private.js containing:
+      EBAY_APP_ID, EBAY_DEV_ID, EBAY_CERT, EBAY_TOKEN
+    `);
+  }
+  const skipTests = !ebay;
+
+  before(function () {
+    if (skipTests) {
+      this.skip();
+    }
+  });
 
   it("is running in sandbox", function () {
     expect(ebay.GetAccount().endpoint).to.equal(Endpoints.Trading.sandbox, "COULD NOT FIND SANDBOX")
@@ -30,7 +51,7 @@ describe("<Ebay> => Functional Testing", function () {
         expect(err).to.be.instanceOf(errors.Ebay_Api_Error)
         done()
       })
-  
+
   })
 
   it("lists items", function (done) {
@@ -103,4 +124,3 @@ describe("<Ebay> => Functional Testing", function () {
       .catch(done)
   })
 })
-

--- a/test/Ebay.Parser.spec.js
+++ b/test/Ebay.Parser.spec.js
@@ -5,7 +5,8 @@ describe("<Ebay.Parser>", function () {
   it("Parser.cast()", function () {
     expect(Parser.cast("true")).to.equal(true)
     expect(Parser.cast("false")).to.equal(false)
-    expect(Parser.cast("1")).to.equal(1)
+    expect(Parser.cast("1")).to.equal("1")
+    expect(Parser.cast("1", "CategoryCount")).to.equal(1)
     expect(Parser.cast("taters")).to.equal("taters")
   })
 })


### PR DESCRIPTION
Per discussion on #51, implement a whitelist for Number conversion, rather than blindly converting anything that looks like a number.  Prevents prices from being converted to weird floats and USPS tracking numbers from being converted into scientific notation.  Will likely necessitate a major version bump, as this could break existing users who may be expecting numbers in output.
